### PR TITLE
Use simpler sed to comment xrandr line in .xprofile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,7 +164,7 @@ read -p "Do you want to keep the xrandr display setup? (yes/no): " xrandr_choice
 
 if [[ "$xrandr_choice" == "no" ]]; then
     echo "Commenting out xrandr setup in .xprofile..."
-    sed -i '/^xrandr --output/ {N; s/^/# /g}' "$USER_HOME/.xprofile"
+    sed -i '/^xrandr --output/s/^/# /' "$USER_HOME/.xprofile"
 fi
 
 # Ask user if they want to set up OpenSSH


### PR DESCRIPTION
## Summary
- Simplify `sed` command in `install.sh` to comment only the `xrandr` line in `.xprofile`.

## Testing
- `bash -n install.sh`
- `sed -i '/^xrandr --output/s/^/# /' /tmp/test2.xprofile && cat /tmp/test2.xprofile`

------
https://chatgpt.com/codex/tasks/task_e_68a5592a184c832383bc68d8494eb2fe