### PR TITLE
Validate SUDO_USER and safely look up user home

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,15 @@ fi
 
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-USER_HOME=$(eval echo ~$SUDO_USER)
+
+# Ensure the script is run via sudo and safely determine the invoking user's home
+if [ -z "$SUDO_USER" ]; then
+    echo "Please run this script via sudo."
+    exit 1
+fi
+
+# Look up the invoking user's home directory using getent for reliability
+USER_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
 
 # Update system
 echo "Updating system..."


### PR DESCRIPTION
## Summary
- Ensure installer is run via `sudo` by checking `SUDO_USER` and exiting if unset
- Resolve invoking user's home directory with `getent` for safer lookup

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a55935df708323a909f6faf7abc2b5