### PR TITLE
Fix hardcoded username in .xprofile wallpaper path

### DIFF
--- a/.xprofile
+++ b/.xprofile
@@ -12,7 +12,7 @@ dwmblocks &
 /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &
 
 # Set wallpaper
-feh --bg-scale /home/matt/Pictures/wallpapers/Debian-Wallpaper-Dark.png &
+feh --bg-scale ~/Pictures/wallpapers/Debian-Wallpaper-Dark.png &
 
 # Launch Thunar daemon in background
 thunar --daemon &


### PR DESCRIPTION
Replace hardcoded /home/matt/ path with generic ~/ in wallpaper configuration. This improves portability across different users and fixes a privacy issue.